### PR TITLE
BE: [fix] 프로필 사진 null 가능하게 수정 #16

### DIFF
--- a/src/backend/src/main/java/RunningMachines/R2R/domain/user/service/AuthCommandService.java
+++ b/src/backend/src/main/java/RunningMachines/R2R/domain/user/service/AuthCommandService.java
@@ -48,11 +48,13 @@ public class AuthCommandService {
         User user = signupRequestDto.toEntity(passwordEncoder.encode(signupRequestDto.getPassword()));
         user = userRepository.save(user);
 
-        String imageUrl = null; // 프로필 사진 입력 안 했을 때 null로 저장할 수 있도록 함
-        imageUrl = s3Provider.uploadFile(image, S3RequestDto.builder()
-                .userId(user.getId())
-                .dirName("profile")
-                .build());
+        String imageUrl = null;
+        if (image != null && !image.isEmpty()) {
+            imageUrl = s3Provider.uploadFile(image, S3RequestDto.builder()
+                    .userId(user.getId())
+                    .dirName("profile")
+                    .build());
+        }
 
         user.setProfileImageUrl(imageUrl);
         return UserResponseDto.of(userRepository.save(user));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #16

## 📝 작업 내용

> 프로필 사진 null 입력 가능하게 수정 
