### PR TITLE
BE: [fix] S3 코스 조회 수정

### DIFF
--- a/src/backend/src/main/java/RunningMachines/R2R/domain/course/service/CourseQueryService.java
+++ b/src/backend/src/main/java/RunningMachines/R2R/domain/course/service/CourseQueryService.java
@@ -31,7 +31,7 @@ public class CourseQueryService {
     public List<CourseResponseDto> getCourses(double lat, double lon) {
         // S3에서 GPX 파일 목록 가져오기
         List<String> fileKeys = s3Provider.getCourseFiles();
-        log.info("총 {}개의 GPX 파일을 가져왔습니다.", fileKeys.size());
+//        log.info("총 {}개의 GPX 파일을 가져왔습니다.", fileKeys.size());
 
         // 파일 처리
         return fileKeys.stream()
@@ -39,7 +39,6 @@ public class CourseQueryService {
                 .toList(); // 리스트로 변환
     }
 
-    // 개별 파일 처리 로직 (예외는 호출자에게 전파)
     private CourseResponseDto processFile(String fileKey) {
         // S3에서 파일 URL 및 원본 파일명 가져오기
         URL url = s3Provider.getFileUrl(fileKey);
@@ -65,7 +64,6 @@ public class CourseQueryService {
             String fileName = gpx.getFileName();
             List<WaypointDto> waypoints = gpx.getWaypoints();
 
-            // TODO - 모델 서버와 연동하여 실제 거리 및 코스명 받아오기
 //            double distance = courseRepository.findDistanceByFileName(fileName); // 임시 저장된 거리 데이터
 //            log.info("Course URL: {}, Distance: {}", gpx.getCourseUrl(), distance);
 //            log.info("Course URL: {}]", gpx.getCourseUrl());

--- a/src/backend/src/main/java/RunningMachines/R2R/global/s3/S3Provider.java
+++ b/src/backend/src/main/java/RunningMachines/R2R/global/s3/S3Provider.java
@@ -67,12 +67,12 @@ public class S3Provider {
             }
 
             // 페이지가 더 있을 경우 추가 로딩 (파일이 1000개 이상일 경우)
-            while (objectListing.isTruncated()) {
-                objectListing = amazonS3Client.listNextBatchOfObjects(objectListing);
-                for (S3ObjectSummary objectSummary : objectListing.getObjectSummaries()) {
-                    gpxs.add(objectSummary.getKey());
-                }
-            }
+//            while (objectListing.isTruncated()) {
+//                objectListing = amazonS3Client.listNextBatchOfObjects(objectListing);
+//                for (S3ObjectSummary objectSummary : objectListing.getObjectSummaries()) {
+//                    gpxs.add(objectSummary.getKey());
+//                }
+//            }
         } catch (Exception e) {
             log.error("Error fetching file list from S3 bucket: {}", e.getMessage(), e);
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> s3 조회시 배포된 서버에서 null list가 받아와짐
<img width="595" alt="image" src="https://github.com/user-attachments/assets/59f776d0-3c92-49f1-be82-7077d0a38cb9">


## 📝 작업 내용

> S3 내 코스 디렉토리 조회 시 추가 로딩 주석 처리