### PR TITLE
BE: [fix] 코스 S3 조회 최대 10개 제한으로 변경 #89

### DIFF
--- a/src/backend/src/main/java/RunningMachines/R2R/global/s3/S3Provider.java
+++ b/src/backend/src/main/java/RunningMachines/R2R/global/s3/S3Provider.java
@@ -62,7 +62,7 @@ public class S3Provider {
             ListObjectsV2Request request = new ListObjectsV2Request()
                     .withBucketName(bucket) // 버킷 이름
                     .withPrefix("course/null/")  // course 디렉토리의 파일
-                    .withMaxKeys(5);        // 최대 5개만 가져오기
+                    .withMaxKeys(10);        // 최대 10개만 가져오기
 
             ListObjectsV2Result result = amazonS3Client.listObjectsV2(request);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #89 

## 📝 작업 내용

> 코스 S3 조회 최대 10개 제한으로 변경 ; 추천 코스 5개 이상인 경우도 있기 때문

#### 스크린샷 (선택)
